### PR TITLE
Fix clarity values / wire types

### DIFF
--- a/src/utils/clarity-responses-util.ts
+++ b/src/utils/clarity-responses-util.ts
@@ -23,6 +23,7 @@ import {
 	responseErrorCV,
 	ClarityWireType,
 	clarityByteToType,
+	Cl,
 } from '@stacks/transactions';
 import { ApiError } from './api-error-util';
 import { ErrorCode } from './error-catalog-util';
@@ -153,10 +154,12 @@ export function convertToClarityValue(arg: ClarityValue | SimplifiedClarityValue
 		if (Object.values(ClarityWireType).includes(arg.type as unknown as ClarityWireType)) {
 			// clone the arg
 			const clonedArg = { ...arg };
+			const serializedArg = Cl.serialize(clonedArg as ClarityValue);
+			const deserializedArg = Cl.deserialize(serializedArg);
 			// convert the type to ClarityType using clarityByteToType
-			clonedArg.type = clarityByteToType(arg.type as unknown as ClarityWireType) as ClarityType;
-			// return the cloned arg as ClarityValue
-			return clonedArg as ClarityValue;
+			// clonedArg.type = clarityByteToType(arg.type as unknown as ClarityWireType) as ClarityType;
+			// return the deserialized arg as ClarityValue
+			return deserializedArg;
 		}
 		// test if we can parse it as a simple object
 		const simplifiedArg = arg as SimplifiedClarityValue;

--- a/src/utils/clarity-responses-util.ts
+++ b/src/utils/clarity-responses-util.ts
@@ -21,9 +21,6 @@ import {
 	someCV,
 	responseOkCV,
 	responseErrorCV,
-	ClarityWireType,
-	clarityByteToType,
-	Cl,
 } from '@stacks/transactions';
 import { ApiError } from './api-error-util';
 import { ErrorCode } from './error-catalog-util';
@@ -143,45 +140,12 @@ export function safeBigIntConversion(value: unknown): bigint {
  * @returns A proper ClarityValue object
  * @throws Error if the type is unsupported or the conversion fails
  */
-export function convertToClarityValue(arg: ClarityValue | SimplifiedClarityValue): ClarityValue {
-	// if it's an object with key 'type'
+export function convertToClarityValue(arg: unknown): ClarityValue {
+	// check if it's an object with the key type to start
 	if (typeof arg === 'object' && arg !== null && 'type' in arg) {
 		// test if the type matches a known ClarityType
 		if (Object.values(ClarityType).includes(arg.type as ClarityType)) {
 			return arg as ClarityValue;
-		}
-		// test if the type matches a known ClarityWireType
-		if (Object.values(ClarityWireType).includes(arg.type as unknown as ClarityWireType)) {
-			// clone the arg
-			const clonedArg = { ...arg };
-			const manualTestArg = {
-				address: {
-					hash160: 'fea47d2d8c68608a9eed74933643706a79009f9d',
-					type: 0,
-					version: 26,
-				},
-				contractName: {
-					content: 'media3-treasury-withdraw-stx-814455',
-					type: 2,
-					lengthPrefixBytes: 1,
-					maxLengthBytes: 128,
-				},
-				type: 6,
-			};
-			console.log({
-				message: 'attempting to clone and serialize arg',
-				arg: arg,
-				clonedArg: clonedArg,
-				manualTestArg: manualTestArg,
-				convertedType: clarityByteToType(arg.type as unknown as ClarityWireType),
-				convertedValue: cvToValue(clonedArg as ClarityValue),
-			});
-			const serializedArg = Cl.serialize(manualTestArg as unknown as ClarityValue);
-			const deserializedArg = Cl.deserialize(serializedArg);
-			// convert the type to ClarityType using clarityByteToType
-			// clonedArg.type = clarityByteToType(arg.type as unknown as ClarityWireType) as ClarityType;
-			// return the deserialized arg as ClarityValue
-			return deserializedArg;
 		}
 		// test if we can parse it as a simple object
 		const simplifiedArg = arg as SimplifiedClarityValue;

--- a/src/utils/clarity-responses-util.ts
+++ b/src/utils/clarity-responses-util.ts
@@ -154,13 +154,29 @@ export function convertToClarityValue(arg: ClarityValue | SimplifiedClarityValue
 		if (Object.values(ClarityWireType).includes(arg.type as unknown as ClarityWireType)) {
 			// clone the arg
 			const clonedArg = { ...arg };
+			const manualTestArg = {
+				address: {
+					hash160: 'fea47d2d8c68608a9eed74933643706a79009f9d',
+					type: 0,
+					version: 26,
+				},
+				contractName: {
+					content: 'media3-treasury-withdraw-stx-814455',
+					type: 2,
+					lengthPrefixBytes: 1,
+					maxLengthBytes: 128,
+				},
+				type: 6,
+			};
 			console.log({
 				message: 'attempting to clone and serialize arg',
 				arg: arg,
 				clonedArg: clonedArg,
+				manualTestArg: manualTestArg,
 				convertedType: clarityByteToType(arg.type as unknown as ClarityWireType),
+				convertedValue: cvToValue(clonedArg as ClarityValue),
 			});
-			const serializedArg = Cl.serialize(clonedArg as ClarityValue);
+			const serializedArg = Cl.serialize(manualTestArg as unknown as ClarityValue);
 			const deserializedArg = Cl.deserialize(serializedArg);
 			// convert the type to ClarityType using clarityByteToType
 			// clonedArg.type = clarityByteToType(arg.type as unknown as ClarityWireType) as ClarityType;

--- a/src/utils/clarity-responses-util.ts
+++ b/src/utils/clarity-responses-util.ts
@@ -110,14 +110,6 @@ export function decodeListRecursively(list: ListCV, strictJsonCompat = true, pre
 }
 
 /**
- * Converts a simplified Clarity value representation to a proper ClarityValue object
- * This allows non-TypeScript clients to use a simpler JSON format for contract calls
- *
- * @param arg - Either a ClarityValue object or a simplified representation
- * @returns A proper ClarityValue object
- * @throws Error if the type is unsupported or the conversion fails
- */
-/**
  * Safely converts a value to BigInt, handling string representations with or without 'n' suffix
  *
  * @param value - The value to convert to BigInt
@@ -142,6 +134,14 @@ export function safeBigIntConversion(value: unknown): bigint {
 	throw new Error(`Cannot convert ${typeof value} to BigInt`);
 }
 
+/**
+ * Converts a simplified Clarity value representation to a proper ClarityValue object
+ * This allows non-TypeScript clients to use a simpler JSON format for contract calls
+ *
+ * @param arg - Either a ClarityValue object or a simplified representation
+ * @returns A proper ClarityValue object
+ * @throws Error if the type is unsupported or the conversion fails
+ */
 export function convertToClarityValue(arg: ClarityValue | SimplifiedClarityValue): ClarityValue {
 	// if it's an object with key 'type'
 	if (typeof arg === 'object' && arg !== null && 'type' in arg) {

--- a/src/utils/clarity-responses-util.ts
+++ b/src/utils/clarity-responses-util.ts
@@ -154,6 +154,12 @@ export function convertToClarityValue(arg: ClarityValue | SimplifiedClarityValue
 		if (Object.values(ClarityWireType).includes(arg.type as unknown as ClarityWireType)) {
 			// clone the arg
 			const clonedArg = { ...arg };
+			console.log({
+				message: 'attempting to clone and serialize arg',
+				arg: arg,
+				clonedArg: clonedArg,
+				convertedType: clarityByteToType(arg.type as unknown as ClarityWireType),
+			});
 			const serializedArg = Cl.serialize(clonedArg as ClarityValue);
 			const deserializedArg = Cl.deserialize(serializedArg);
 			// convert the type to ClarityType using clarityByteToType


### PR DESCRIPTION
Object formats don't match between what Cl.principal() produces as a wire format and ClarityValue expects as a contract principal. Suspecting a conversion happens under the hood with fetchCallReadOnlyFunction() but this might be a valid workaround.

Trying to pass this to the API is what triggered it:

```
contractId: ST252TFQ08T74ZZ6XK426TQNV4EXF1D4RMTTNCWFA.media3-core-proposals-v2
url: https://cache-staging.aibtc.dev/contract-calls/read-only/ST252TFQ08T74ZZ6XK426TQNV4EXF1D4RMTTNCWFA/media3-core-proposals-v2/get-proposal
body: {
  "functionArgs": [
    {
      "type": 6,
      "address": {
        "type": 0,
        "version": 26,
        "hash160": "fea47d2d8c68608a9eed74933643706a79009f9d"
      },
      "contractName": {
        "type": 2,
        "content": "media3-treasury-withdraw-stx-814455",
        "lengthPrefixBytes": 1,
        "maxLengthBytes": 128
      }
    }
  ],
  "network": "testnet",
  "senderAddress": "ST3ZA8Z9DHHM612MYXNT96DJ3E1N7J04ZKQ3H2FSP",
  "cacheControl": {}
}
result: {
  "success": false,
  "error": {
    "id": "bda11500",
    "code": "UPSTREAM_API_ERROR",
    "message": "Upstream API error: Cannot read properties of undefined (reading 'split')",
    "details": {
      "message": "Cannot read properties of undefined (reading 'split')",
      "contract": "ST252TFQ08T74ZZ6XK426TQNV4EXF1D4RMTTNCWFA.media3-core-proposals-v2",
      "function": "get-proposal",
      "network": "testnet",
      "duration": 0,
      "requestId": "c04d030c"
    }
  }
}
```